### PR TITLE
Ensure $request is passed through to callable

### DIFF
--- a/tests/Prosaic/RequestHandler/CallableRequestHandlerTest.php
+++ b/tests/Prosaic/RequestHandler/CallableRequestHandlerTest.php
@@ -27,7 +27,9 @@ final class CallableRequestHandlerTest extends TestCase
         $request = (new ServerRequest())
             ->withAttribute('msg', 'Hello There');
 
-        $requestHandler = new CallableRequestHandler(static fn () => new TextResponse($request->getAttribute('msg')));
+        $requestHandler = new CallableRequestHandler(
+            static fn (ServerRequest $request) => new TextResponse($request->getAttribute('msg'))
+        );
 
         self::assertEquals(
             'Hello There',


### PR DESCRIPTION
The original test was relying on the `$request` variable defined outside
the callable. Therefore this test passing was actually a false positive
as it wasn't testing that the request was passed through to the
callable.

After experimenting to ensure the `$request` defined in the arrow function's parameters will take precedence over the `$request` in the test method's scope I concluded that this is all I had to change. However, if you would rather be more explicit about which one will be used then I could rename the variable, put it after the `$requestHandler` definition, or inline the `ServerRequest` instantiation to the assertion. Let me know what you would rather do and I will update the PR accordingly.